### PR TITLE
Added examples demo using CodeSandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # use-click-outside
+
 Simple React hook to detect when a click happens outside a component.
 Useful for implementing modal dialogs and popups.
 
@@ -15,66 +16,71 @@ npm install @sweepbright/use-click-ouside
 ### Usage
 
 ```javascript
-import  {useClickOutside} from '@sweepbright/use-click-outside'
-
+import { useClickOutside } from '@sweepbright/use-click-outside';
 
 function Popup() {
-    const ref= React.useRef(null)
-    const onClickOutside = React.useCallback(() => {
-        alert('clicked outside element')
-    })
+  const ref = React.useRef(null);
+  const onClickOutside = React.useCallback(() => {
+    alert('clicked outside element');
+  });
 
-    useClickOuside(ref, {
-        onClickOutside
-    })
+  useClickOuside(ref, {
+    onClickOutside,
+  });
 
-    return <div ref={ref}> Hello </div>
-
+  return <div ref={ref}> Hello </div>;
 }
 ```
 
+Here, I provide you two examples where you can see how can be used the library.
+
+**Simple example**: https://codesandbox.io/s/cocky-mountain-1mmtz
+**Advanced example**: https://codesandbox.io/s/falling-leftpad-kp8sr
 
 ### API
 
 ```javascript
-useClickOutside(ref, config, deps)
+useClickOutside(ref, config, deps);
 ```
 
 ### Params
+
 #### `ref`
 
-| Param   | Type         | Description                                                                      |
-| ------- | ------------ | -------------------------------------------------------------------------------  |
-| `ref`   | RefObject    | A  mutable ref object whose `current` property points target element DOM node    |
+| Param | Type      | Description                                                                  |
+| ----- | --------- | ---------------------------------------------------------------------------- |
+| `ref` | RefObject | A mutable ref object whose `current` property points target element DOM node |
 
 #### `config`
 
-| Param   | Type         | Description                                                                      |
-| ------- | ------------ | -------------------------------------------------------------------------------  |
-| `config`   | Object    |  A configuration object for the behavior of the hook          |
+| Param    | Type   | Description                                         |
+| -------- | ------ | --------------------------------------------------- |
+| `config` | Object | A configuration object for the behavior of the hook |
 
 #### Config options
+
 The following options are supported
-* `onClickOutside: (evt: MouseEvent) => void`
-    * Required
-    * Must be *memoized*
-    * Will be called every time a click outside the target element is detected
-    * It is passed the click event object
-* `skip: boolean`
-    * Optional
-    * Defaults to `false`
-    * Useful when you want to skip the listener. It can be used as a perf improvement when you know the element target element is not in the DOM.
+
+- `onClickOutside: (evt: MouseEvent) => void`
+  - Required
+  - Must be _memoized_
+  - Will be called every time a click outside the target element is detected
+  - It is passed the click event object
+- `skip: boolean`
+  - Optional
+  - Defaults to `false`
+  - Useful when you want to skip the listener. It can be used as a perf improvement when you know the element target element is not in the DOM.
 
 #### `deps`
 
-| Param   | Type         | Description                                                                      |
-| ------- | ------------ | -------------------------------------------------------------------------------  |
-| `deps`   | Array    | Optional dependency array |
+| Param  | Type  | Description               |
+| ------ | ----- | ------------------------- |
+| `deps` | Array | Optional dependency array |
 
 ### Contributing
+
 TODO
 
-
-
 ### License
+
 MIT


### PR DESCRIPTION
This updates the file README.md which now provides two examples with its links in CodeSandbox. 

- A simple example, which code is in the following link: https://codesandbox.io/s/cocky-mountain-1mmtz

- A more advanced example, which code is in the following link: https://codesandbox.io/s/falling-leftpad-kp8sr. 

At the moment, the last one has a button and when it is clicked shows a popup window but doesn't use the library yet. The mouse event needs to be caught [WIP].